### PR TITLE
bump the cereal dependency to support 0.5.*

### DIFF
--- a/grid.cabal
+++ b/grid.cabal
@@ -33,7 +33,7 @@ source-repository this
 library
   hs-source-dirs:  src
   build-depends:   base ==4.*,
-                   cereal ==0.4.*,
+                   cereal >=0.4 && < 0.6,
                    containers ==0.5.*
   ghc-options:     -Wall
   exposed-modules: Math.Geometry.Grid,
@@ -69,4 +69,3 @@ test-suite grid-tests
                    Math.Geometry.Grid.SquareQC,
                    Math.Geometry.Grid.TriangularQC
                    Math.Geometry.GridMap.LazyQC
-


### PR DESCRIPTION
This builds and tests pass, so I guess it should be fine. This is also the only dependency that's preventing grid from being usable with current Stackage LTS.