### PR TITLE
Fix build in GHC 8.0 by adding ConstrainedClassMethods pragma

### DIFF
--- a/src/Math/Geometry/GridInternal.hs
+++ b/src/Math/Geometry/GridInternal.hs
@@ -11,7 +11,7 @@
 -- use @Grid@ instead. This module is subject to change without notice.
 --
 ------------------------------------------------------------------------
-{-# LANGUAGE TypeFamilies, FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies, FlexibleContexts, ConstrainedClassMethods #-}
 
 module Math.Geometry.GridInternal where
 


### PR DESCRIPTION
Without this pragma, GHC reports multiple errors of the form

```
/Users/tim/Software/grid/src/Math/Geometry/GridInternal.hs:52:3: error:
    • Constraint ‘Eq (Index g)’ in the type of ‘neighbours’
        constrains only the class type variables
      Use ConstrainedClassMethods to allow it
    • When checking the class method:
        neighbours :: forall g.
                      (Grid g, Eq (Index g)) =>
                      g -> Index g -> [Index g]
      In the class declaration for ‘Grid’
```

This pragma has been in GHC since version 7.0, so this should not break backwards compatibility.