### PR TITLE
Add Bounded and Wrapped instances for LGridMap

### DIFF
--- a/src/Math/Geometry/GridMap/Lazy.hs
+++ b/src/Math/Geometry/GridMap/Lazy.hs
@@ -91,8 +91,8 @@ instance G.BoundedGrid g => G.BoundedGrid (LGridMap g v) where
   tileSideCount (LGridMap g _) = G.tileSideCount g
 
 instance G.WrappedGrid g => G.WrappedGrid (LGridMap g v) where
-  normalise (LGridMap g _) k = G.normalise g k
-  denormalise (LGridMap g _) k = G.denormalise g k
+  normalise (LGridMap g _) = G.normalise g
+  denormalise (LGridMap g _) = G.denormalise g
 
 instance (G.Grid g) => GridMap (LGridMap g) v where
   type BaseGrid (LGridMap g) v = g

--- a/src/Math/Geometry/GridMap/Lazy.hs
+++ b/src/Math/Geometry/GridMap/Lazy.hs
@@ -32,7 +32,7 @@ import qualified Data.Map as M
 --import qualified Data.Map.Strict as Strict (Map)
 import Data.Maybe (fromMaybe)
 import GHC.Generics (Generic)
-import qualified Math.Geometry.Grid as G
+import qualified Math.Geometry.GridInternal as G
 import Math.Geometry.GridMap
 
 -- | A map from tile positions in a grid to values.
@@ -86,6 +86,13 @@ instance G.FiniteGrid g => G.FiniteGrid (LGridMap g v) where
   type Size (LGridMap g v) = G.Size g
   size (LGridMap g _) = G.size g
   maxPossibleDistance (LGridMap g _) = G.maxPossibleDistance g
+
+instance G.BoundedGrid g => G.BoundedGrid (LGridMap g v) where
+  tileSideCount (LGridMap g _) = G.tileSideCount g
+
+instance G.WrappedGrid g => G.WrappedGrid (LGridMap g v) where
+  normalise (LGridMap g _) k = G.normalise g k
+  denormalise (LGridMap g _) k = G.denormalise g k
 
 instance (G.Grid g) => GridMap (LGridMap g) v where
   type BaseGrid (LGridMap g) v = g


### PR DESCRIPTION
I noticed when trying to use `normalise` on a `grid :: LGridMap TorOctGrid v` that the `WrappedGrid` typeclass wasn't available, even though `TorOctGrid` has one. I went ahead and added both missing typeclass instances for `LGridMap`.

If you want to add them, I believe this suffices. Tests are passing anyways.