### PR TITLE
Bump upper bound on QuickCheck

### DIFF
--- a/grid.cabal
+++ b/grid.cabal
@@ -58,7 +58,7 @@ test-suite grid-test
                        containers,
                        test-framework ==0.8.*,
                        test-framework-quickcheck2 ==0.3.*,
-                       QuickCheck >=2.8 && <2.10
+                       QuickCheck >=2.8 && <2.11
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
   default-language:    Haskell2010
 


### PR DESCRIPTION
`grid` cannot be build by nix because of the upper bound on `QuickCheck` (`<2.10`)

Tested that it compiles locally with the newest stack lts that has `QuickCheck-2.10.*` and bumped the bound to `<2.11`

